### PR TITLE
Optimize IntersectionObserver with useMemo in LazyBackground

### DIFF
--- a/my-react-app/src/components/LazyBackground.jsx
+++ b/my-react-app/src/components/LazyBackground.jsx
@@ -1,23 +1,26 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 
 function LazyBackground({ src, children, className, style, placeholder = '#242424' }) {
   const [isLoaded, setIsLoaded] = useState(false);
   const [isInView, setIsInView] = useState(false);
   const elementRef = useRef(null);
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
+  const observer = useMemo(() => {
+    const instance = new IntersectionObserver(
       (entries) => {
         entries.forEach(entry => {
           if (entry.isIntersecting) {
             setIsInView(true);
-            observer.unobserve(entry.target);
+            instance.unobserve(entry.target);
           }
         });
       },
-      { threshold: 0.1, rootMargin: '200px' } // Start loading when within 200px of viewport
+      { threshold: 0.5, rootMargin: '200px' }
     );
+    return instance;
+  }, []);
 
+  useEffect(() => {
     const currentElement = elementRef.current;
     if (currentElement) {
       observer.observe(currentElement);
@@ -28,7 +31,7 @@ function LazyBackground({ src, children, className, style, placeholder = '#24242
         observer.unobserve(currentElement);
       }
     };
-  }, []);
+  }, [observer]);
 
   // Load image when in view
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Set threshold to 0.5 in LazyBackground component's IntersectionObserver
- Optimized useMemo implementation to prevent recreation on each render

Closes #59

## Test plan
- Verify LazyBackground loads images only when 50% visible
- Confirm component renders and functions correctly
- Existing tests for LazyBackground still pass